### PR TITLE
关于几个使用过程中发现的bug问题修复

### DIFF
--- a/src/assets/style/panel.less
+++ b/src/assets/style/panel.less
@@ -286,8 +286,9 @@
   }
 
   &-disabled {
-    color: rgba(255, 255, 255, 0.7) !important;
-    text-shadow: 1px 1px 1px #7a7a7a;
+    // color: rgba(255, 255, 255, 0.7) !important;
+    // text-shadow: 1px 1px 1px #7a7a7a;
+    color: #aaa !important;
     cursor: not-allowed;
 
     .date-picker--panel-value--lunar {

--- a/src/components/comps/TimeWheel.vue
+++ b/src/components/comps/TimeWheel.vue
@@ -1,20 +1,20 @@
 <template>
   <div class="date-picker--panel-time-wheel" @wheel="onWheel">
-    <div class="date-picker--panel-time-wheel-prev-button datepicker-iconfont datepicker--icon-top"
+      <div class="date-picker--panel-time-wheel-prev-button datepicker-iconfont datepicker--icon-top"
          @mousedown="onButtonDown('prev')" @mouseup="onButtonUp('prev')"></div>
     <div class="date-picker--panel-time-wheel-prev">
       <span :class="getCellClass(getPrevValue(prevValue))" @click="goPrev(1)">{{ getPrevValue(prevValue) | pad }}</span>
-      <span :class="getCellClass(prevValue)" @click="goPrev">{{ prevValue | pad }}</span>
+      <span :class="getCellClass(prevValue)" @click="goPrev(0)">{{ prevValue | pad }}</span>
     </div>
-    <div class="date-picker--panel-time-wheel-value">
+    <div class="date-picker--panel-time-wheel-value" style="border-top:1px solid;border-bottom:1px solid;background: rgb(19 125 226 / 15%)">
       <span :class="getCellClass(viewValue)">{{ viewValue| pad }}</span>
     </div>
     <div class="date-picker--panel-time-wheel-next">
-      <span :class="getCellClass(nextValue)" @click="goNext">{{ nextValue| pad }}</span>
+      <span :class="getCellClass(nextValue)" @click="goNext(0)">{{ nextValue| pad }}</span>
       <span :class="getCellClass(getNextValue(nextValue))" @click="goNext(1)">{{ getNextValue(nextValue)| pad }}</span>
     </div>
-    <div class="date-picker--panel-time-wheel-next-button datepicker-iconfont datepicker--icon-bottom"
-         @mousedown="onButtonDown('prev')" @mouseup="onButtonUp('prev')"></div>
+      <div class="date-picker--panel-time-wheel-next-button datepicker-iconfont datepicker--icon-bottom"
+         @mousedown="onButtonDown('next')" @mouseup="onButtonUp('next')"></div>
   </div>
 </template>
 
@@ -110,7 +110,7 @@ export default {
       }
     },
     goPrev(offset) {
-      this.viewValue = offset ? this.getPrevValue(this.prevValue) : this.prevValue
+       this.viewValue = offset ? this.getPrevValue(this.prevValue) : this.prevValue
 
       if (this.isDisabled(this.viewValue)) {
         this.$emit('update:disabled', true)
@@ -121,7 +121,7 @@ export default {
     },
     goNext(offset) {
       this.viewValue = offset ? this.getNextValue(this.nextValue) : this.nextValue
-      if (this.isDisabled(this.viewValue)) {
+     if (this.isDisabled(this.viewValue)) {
         this.$emit('update:disabled', true)
         return
       }

--- a/src/components/panels/TimePanel.vue
+++ b/src/components/panels/TimePanel.vue
@@ -6,7 +6,7 @@
     <div class="date-picker--panel-body">
       <div class="date-picker--panel-time--body">
           <div class="date-picker--panel-time--value">
-            <span>{{ this.time.hour | pad }}</span>
+            <span>{{ this.time.hour | pad }}</span> 
             <time-wheel class="date-picker--panel-time-h" :value.sync="time.hour" :disabled.sync="disabled.hour"
                         :data="hours"/>
           </div>
@@ -27,7 +27,7 @@
 </template>
 
 <script>
-import mixin from '../mixins/panel'
+import mixin from '../mixins/panel' 
 import TimeWheel from '../comps/TimeWheel'
 import util from '../../assets/script/util'
 
@@ -67,11 +67,11 @@ export default {
           v.second === this.viewValue.getSeconds()) {
           return
         }
-        if (!this.initialized) {
-          this.initialized = true
-          return
-        }
-
+        //该行代码导致选中时间后第一次更改不刷新数据，不知道原作者为何设置改代码，暂时保留
+        // if (!this.initialized) {
+        //   this.initialized = true
+        //   return
+        // }
         this.viewValue = util.setDate(this.viewValue, v)
         this.onPick()
       }
@@ -100,11 +100,12 @@ export default {
       const data = {
         max
       }
-
+     const currentDay=this.picker.value   //当前时间
+     let currentMin=currentDay?Number(currentDay.substr(14,2)):0     //当前时间的分钟数
+     let currentSec=currentDay?Number(currentDay.substr(17,2)):0   //当前时间的秒
       for (let i = 0; i <= max; i++) {
-        data[i] = this.validate({hour: i, minute: 0, second: 0})
+        data[i] = this.validate({hour: i, minute: currentMin, second: currentSec})
       }
-
       return data
     },
     minutes() {
@@ -112,12 +113,13 @@ export default {
       const data = {
         max
       }
-
+      const currentDay=this.picker.value   //当前时间
+     let currentSec=currentDay?Number(currentDay.substr(17,2)):0   //当前时间的秒
       for (let i = 0; i <= max; i++) {
         data[i] = this.disabled.hour ? false : this.validate({
           hour: this.time.hour,
           minute: i,
-          second: 0
+          second: currentSec
         })
       }
 


### PR DESCRIPTION
1.当最小时间选择为非整点时候，最小时间的时不可选，比如最小时间 min="2022-01-25 17:30:00" ，但是17时不允许选的。
![151083121-970bd16d-3dd3-464f-a493-9df82fe0ebff](https://user-images.githubusercontent.com/31644862/157815042-7b3168e5-a587-4a27-8fb8-5511b988aad5.png)
2.时分秒的时间轴点击上和下会跳两个时间节点的bug修复
3.在配置时间范围时，选择结束时间时，时间轴滑动的第一下没有反应bug修复
![image](https://user-images.githubusercontent.com/31644862/157815964-f14bc389-0a0b-4a3b-a01a-d000574aaf68.png)
4.选中时间颜色高亮配置优化
![image](https://user-images.githubusercontent.com/31644862/157816080-5c50a6f4-218a-462a-9642-61e70c2a241a.png)
